### PR TITLE
Updated for Python 3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 Python raytracer
 
 The speed difference is explained at http://www.excamera.com/sphinx/article-ray.html
+
+Updated for Python 3.x.
+
+You'll need to install two packages.
+
+1. Pillow is a fork of the PIL package.  It provides the Image module for this application.
+to install it run the following.
+```
+pip install pillow
+```
+2. Numpy is a scientific package that helps with mathematical functions.
+```
+pip install numpy
+```

--- a/raytracing.py
+++ b/raytracing.py
@@ -1,3 +1,4 @@
+from PIL import Image
 import numpy as np
 
 w = 400
@@ -133,7 +134,7 @@ S = (-1., -1. / r + .25, 1., 1. / r + .25)
 # Loop through all pixels.
 for i, x in enumerate(np.linspace(S[0], S[2], w)):
     if i % 10 == 0:
-        print i / float(w) * 100, "%"
+        print(i / float(w) * 100, "%")
     for j, y in enumerate(np.linspace(S[1], S[3], h)):
         col[:] = 0
         Q[:2] = (x, y)
@@ -154,6 +155,5 @@ for i, x in enumerate(np.linspace(S[0], S[2], w)):
             reflection *= obj.get('reflection', 1.)
         img[h - j - 1, i, :] = np.clip(col, 0, 1)
 
-import Image
 im = Image.fromarray((255 * img).astype(np.uint8), "RGB")
 im.save("fig.png")

--- a/rt2.py
+++ b/rt2.py
@@ -1,3 +1,5 @@
+from PIL import Image
+from functools import reduce
 import numpy as np
 import time
 
@@ -110,8 +112,7 @@ y = np.repeat(np.linspace(S[1], S[3], h), w)
 t0 = time.time()
 Q = vec3(x, y, 0)
 color = raytrace(E, (Q - E).norm(), scene)
-print "Took", time.time() - t0
+print("Took", time.time() - t0)
 
-import Image
 rgb = [Image.fromarray((255 * np.clip(c, 0, 1).reshape((h, w))).astype(np.uint8), "L") for c in color.components()]
-Image.merge("RGB", rgb).save("fig.png")
+Image.merge("RGB", rgb).save("rt2.png")

--- a/rt3.py
+++ b/rt3.py
@@ -1,4 +1,5 @@
-import Image
+from PIL import Image
+from functools import reduce
 import numpy as np
 import time
 import numbers
@@ -40,8 +41,8 @@ class vec3():
 rgb = vec3
 
 (w, h) = (400, 300)         # Screen size
-L = vec3(5, 5., -10)        # Point light position
-E = vec3(0., 0.35, -1.)     # Eye position
+L = vec3(5, 5, -10)        # Point light position
+E = vec3(0, 0.35, -1)     # Eye position
 FARAWAY = 1.0e39            # an implausibly huge distance
 
 def raytrace(O, D, scene, bounce = 0):
@@ -119,22 +120,22 @@ class CheckeredSphere(Sphere):
         return self.diffuse * checker
 
 scene = [
-    Sphere(vec3(.75, .1, 1.), .6, rgb(0, 0, 1)),
+    Sphere(vec3(.75, .1, 1), .6, rgb(0, 0, 1)),
     Sphere(vec3(-.75, .1, 2.25), .6, rgb(.5, .223, .5)),
-    Sphere(vec3(-2.75, .1, 3.5), .6, rgb(1., .572, .184)),
+    Sphere(vec3(-2.75, .1, 3.5), .6, rgb(1, .572, .184)),
     CheckeredSphere(vec3(0,-99999.5, 0), 99999, rgb(.75, .75, .75), 0.25),
     ]
 
 r = float(w) / h
 # Screen coordinates: x0, y0, x1, y1.
-S = (-1., 1. / r + .25, 1., -1. / r + .25)
+S = (-1, 1 / r + .25, 1, -1 / r + .25)
 x = np.tile(np.linspace(S[0], S[2], w), h)
 y = np.repeat(np.linspace(S[1], S[3], h), w)
 
 t0 = time.time()
 Q = vec3(x, y, 0)
 color = raytrace(E, (Q - E).norm(), scene)
-print "Took", time.time() - t0
+print ("Took", time.time() - t0)
 
 rgb = [Image.fromarray((255 * np.clip(c, 0, 1).reshape((h, w))).astype(np.uint8), "L") for c in color.components()]
-Image.merge("RGB", rgb).save("fig.png")
+Image.merge("RGB", rgb).save("rt3.png")

--- a/watch.py
+++ b/watch.py
@@ -1,6 +1,7 @@
+from PIL import Image
+from functools import reduce
 import numpy as np
 import time
-import Image
 
 class vec3():
     def __init__(self, x, y, z):
@@ -118,7 +119,7 @@ y = np.repeat(np.linspace(S[1], S[3], h), w)
 t0 = time.time()
 Q = vec3(x, y, 1)
 color = raytrace(E, (Q - E).norm(), scene)
-print "Took", time.time() - t0
+print ("Took", time.time() - t0)
 
 rgb = [Image.fromarray((255 * np.clip(c, 0, 1).reshape((h, w))).astype(np.uint8), "L") for c in color.components()]
 Image.merge("RGB", rgb).save("fig.png")


### PR DESCRIPTION
Added Pillow (PIL) for Image module support.
Imported "reduce" module from "functools" as "reduce" module had been moved into there in Python 3.
Removed more Image imports that were redundant.
Removed inconsistent and unessissary full stops after some whole numbers.
Updated README.md to reflect changes and add further instructions to help someone with a vanilla Python install get it working.
Gave rt3.py and rt2.py different file outputs for clarity.